### PR TITLE
Feature/fix blob parsing

### DIFF
--- a/src/main/scala/devsearch/AstExtractor.scala
+++ b/src/main/scala/devsearch/AstExtractor.scala
@@ -62,8 +62,8 @@ object SnippetParser extends RegexParsers with java.io.Serializable {
 
   val number:  Parser[String] = """\d+""".r
   val noSlash: Parser[String] = """[^/]+""".r
-  val path:    Parser[String] = """[^\n]+""".r                 //everything until eol
-  val code:    Parser[String] = """(?s).*[^\n\d+:]""".r        //everything until "\n897162346:"
+  val path:    Parser[String] = """[^\n]+""".r        // everything until eol
+  val code:    Parser[String] = """(?s).*""".r        // rest of the string
 }
 
 

--- a/src/main/scala/devsearch/CodeEater.scala
+++ b/src/main/scala/devsearch/CodeEater.scala
@@ -10,7 +10,10 @@ import org.apache.spark.rdd.RDD
  */
 object CodeEater {
   /**
-   * Eats code and returns distinct features (no duplicates)
+   * Eats code and returns features
+   * XXX: features aren't explicitly made distinct, but the collection methods on
+   *      the AST used during feature extraction create feature sets, so identical
+   *      features (ie, same file, same position) will be removed by set semantics.
    */
   def eat(inputData: RDD[CodeFileData]): RDD[Feature] = {
     inputData.flatMap(Features)

--- a/src/test/scala/devsearch/AstExtractorTest.scala
+++ b/src/test/scala/devsearch/AstExtractorTest.scala
@@ -37,6 +37,29 @@ class AstExtractorTest extends FlatSpec {
     // Strange string concat because SPACE on 5th line is always deleted when saving in intelliJ.
   }
 
+  it should "not fail in the presence of an \\n:[\\d+] sequence in the code" in {
+      val s =
+        """133:Java/samarion/repo-name/path/to/file
+          |class ClassWithAConstructor {
+          |  protected ClassWithAConstructor(int a, String b) throws This, AndThat, AndWhatElse {
+          |123:fail!
+          |  }
+          |}
+          |25:Java/hubifant/another_repo/path/to/another/repo
+          |while(!asleep)
+          |  sheep++""".stripMargin
+
+    assert(AstExtractor.toBlobSnippet(("blob/path", s)) == List("""133:Java/samarion/repo-name/path/to/file
+                                                                  |class ClassWithAConstructor {
+                                                                  |  protected ClassWithAConstructor(int a, String b) throws This, AndThat, AndWhatElse {
+                                                                  |123:fail!
+                                                                  |  }
+                                                                  |}""".stripMargin,
+                                                               """|25:Java/hubifant/another_repo/path/to/another/repo
+                                                                  |while(!asleep)
+                                                                  |  sheep++""".stripMargin))
+  }
+
   it should "correctly parse this String containing one file" in {
     val s =
       """9999:Java/samarion/repo-name/path/to/file


### PR DESCRIPTION
The code parsing rule was sightly wrong, this fixes it
(see https://github.com/devsearch-epfl/devsearch-ast/pull/2/files#r28274743)
