### PR TITLE
Feature/preparer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The `splitter.pl` script splits the megablobs (650MB) from `devsearch-concat` in
     * `hadoop fs -mkdir /projects/devsearch/pwalch/usable_repos/java`
     * `hadoop fs -put miniblobs/part-* /projects/devsearch/pwalch/usable_repos/java`
 
-===================================================================================
 
 # DataPreparer
 The DataPreparer is used for joining the features with the repoRank, counting the features, convert everything into JSON and split it into different buckets. Further it generates some stats if wished. 

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ The DataPreparer is used for joining the features with the repoRank, counting th
     * 5th argument is the number of buckets
     * 6th argument tells if stats shall be created or not. ('Y' = define stats)
 * Allocate enough resources to the job. We deal with a large amount of data and especially the join is extremely resource consuming!
--> Example: `spark-submit --num-executors 340 --driver-memory 4g --executor-memory 4g --class "devsearch.prepare.DataPreparer" --master yarn-client "devsearch-learning-assembly-0.1.jar" "/projects/devsearch/pwalch/features/dataset01/*/*,/projects/devsearch/pwalch/features/dataset02/*" "/projects/devsearch/ranking/*" "/projects/devsearch/testJsonBuckets" 100 15 y` 
+* Example: `spark-submit --num-executors 340 --driver-memory 4g --executor-memory 4g --class "devsearch.prepare.DataPreparer" --master yarn-client "devsearch-learning-assembly-0.1.jar" "/projects/devsearch/pwalch/features/dataset01/*/*,/projects/devsearch/pwalch/features/dataset02/*" "/projects/devsearch/ranking/*" "/projects/devsearch/testJsonBuckets" 100 15 y` 

--- a/README.md
+++ b/README.md
@@ -37,3 +37,20 @@ The `splitter.pl` script splits the megablobs (650MB) from `devsearch-concat` in
 * Put files back on HDFS
     * `hadoop fs -mkdir /projects/devsearch/pwalch/usable_repos/java`
     * `hadoop fs -put miniblobs/part-* /projects/devsearch/pwalch/usable_repos/java`
+
+===================================================================================
+
+# DataPreparer
+The DataPreparer is used for joining the features with the repoRank, counting the features, convert everything into JSON and split it into different buckets. Further it generates some stats if wished. 
+
+## Usage
+
+* Use `learning.jar` (generated as discribed above)
+* The DataPreparer is executed with the following arguments:
+    * 1st argument is the input directory containing the feature files
+    * 2nd argument is the input directory containing the repoRank files
+    * 3rd argument is the output directory of the buckets
+    * 4th argument is the minimum number of counts. Features with a lower count are not being saved in the featureCount.
+    * 5th argument is the number of buckets
+    * 6th argument tells if stats shall be created or not. ('Y' = define stats)
+* Run Spark DataPreparer `spark-submit --num-executors 340 --driver-memory 4g --executor-memory 4g --class "devsearch.prepare.DataPreparer" --master yarn-client "devsearch-learning-assembly-0.1.jar" "/projects/devsearch/pwalch/features/dataset01/*/*,/projects/devsearch/pwalch/features/dataset02/*" "/projects/devsearch/ranking/*" "/projects/devsearch/testJsonBuckets" 100 15 y` 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `splitter.pl` script splits the megablobs (650MB) from `devsearch-concat` in
 
 # DataPreparer
 The DataPreparer is used for joining the features with the repoRank, counting the features, convert everything into JSON and split it into different buckets. Further it generates some stats if wished. 
+The script generates directories in the specified output directory and saves the output there.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -52,4 +52,5 @@ The DataPreparer is used for joining the features with the repoRank, counting th
     * 4th argument is the minimum number of counts. Features with a lower count are not being saved in the featureCount.
     * 5th argument is the number of buckets
     * 6th argument tells if stats shall be created or not. ('Y' = define stats)
-* Run Spark DataPreparer `spark-submit --num-executors 340 --driver-memory 4g --executor-memory 4g --class "devsearch.prepare.DataPreparer" --master yarn-client "devsearch-learning-assembly-0.1.jar" "/projects/devsearch/pwalch/features/dataset01/*/*,/projects/devsearch/pwalch/features/dataset02/*" "/projects/devsearch/ranking/*" "/projects/devsearch/testJsonBuckets" 100 15 y` 
+* Allocate enough resources to the job. We deal with a large amount of data and especially the join is extremely resource consuming!
+-> Example: `spark-submit --num-executors 340 --driver-memory 4g --executor-memory 4g --class "devsearch.prepare.DataPreparer" --master yarn-client "devsearch-learning-assembly-0.1.jar" "/projects/devsearch/pwalch/features/dataset01/*/*,/projects/devsearch/pwalch/features/dataset02/*" "/projects/devsearch/ranking/*" "/projects/devsearch/testJsonBuckets" 100 15 y` 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/src/main/scala/devsearch/prepare/DataPreparer.scala
+++ b/src/main/scala/devsearch/prepare/DataPreparer.scala
@@ -199,9 +199,9 @@ object DataPreparer {
 
       //get the most frequent features (dirty hack for saving as file in HDFS)
       sc.parallelize(globalCount.map{case ((feature, language), count) => (count, (feature, language))}
-                                .takeOrdered(100)
+                                .takeOrdered(100)(Ordering[Int].reverse.on(_._1))
                                 .map{case (count, (feature, language)) => feature +"("+ language +"),"+ count }
-                    ).saveAsTextFile(outputPath + "/stats/mostFrequent")
+                    ).saveAsTextFile(outputPath + "/stats/top100")
 
 
 

--- a/src/main/scala/devsearch/prepare/SerializableHashRing.scala
+++ b/src/main/scala/devsearch/prepare/SerializableHashRing.scala
@@ -49,18 +49,18 @@ class SerializableHashRing(inputs: Seq[HashRingNode]) extends java.io.Serializab
     md5.update(input.getBytes)
     val digest = md5.digest()
     ByteBuffer.wrap(digest).getLong
-    /*
+/*
     val crc = new CRC32()
     crc.update(input.getBytes)
     crc.getValue
-    */
+*/
   }
 
   private def _generatePositions(node: HashRingNode): List[Long] = {
     val range = 1 to node.weight
 
     range.foldLeft(List[Long]()) { (memo, i) =>
-      this._stringToCRC(node.value + i.toString)  :: memo
+      this._stringToCRC(node.value + "_" +i.toString)  :: memo
     }
   }
 


### PR DESCRIPTION
The DataPreparer does now count the number of occurrences of each feature per language. This information is saved in JSON format. Example: '{"feature":"variableDeclaration=days type=Int","language":"java","count":{"$numberInt":"487"}}'

The features are counted globally (saved in directory outputDir/globalCount) and partition wise (saved in directory outputDir/partitionCounts/bucketX). 
